### PR TITLE
add deconstruct for compatibility with latest django migrations

### DIFF
--- a/src/naturalsortfield/fields.py
+++ b/src/naturalsortfield/fields.py
@@ -9,18 +9,25 @@ class NaturalSortField(models.CharField):
         kwargs.setdefault('editable', False)
         kwargs.setdefault('max_length', 255)
         super(NaturalSortField, self).__init__(**kwargs)
-    
+        self.max_length = kwargs['max_length']
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(NaturalSortField, self).deconstruct()
+        args.append(self.for_field)
+        return name, path, args, kwargs
+
     def pre_save(self, model_instance, add):
         return self.naturalize(getattr(model_instance, self.for_field))
-    
+
     def naturalize(self, string):
         def naturalize_int_match(match):
             return '%08d' % (int(match.group(0)),)
-        
+
         string = string.lower()
         string = string.strip()
         string = re.sub(r'^the\s+', '', string)
         string = re.sub(r'\d+', naturalize_int_match, string)
-        
+        string = string[:self.max_length]
+
         return string
 


### PR DESCRIPTION
This has been modified in a couple of the forks out there, but I haven't seen a PR to merge this back so that a new version could be released.

Please take a look, the deconstruct method just ensures compatibility with the latest versions of django.